### PR TITLE
Add LLMAgentExecutor module

### DIFF
--- a/src/decision/__init__.py
+++ b/src/decision/__init__.py
@@ -1,1 +1,16 @@
-# decision module
+"""Decision layer components."""
+
+from .agent_executor import ExecutionContext, LLMAgentExecutor
+from .prompt_builder import PromptBuilder
+from .inference_engine import LLMInferenceEngine
+from .refinement_loop import RefinementLoop
+from .output_schema import LLMOutputSchema
+
+__all__ = [
+    "ExecutionContext",
+    "LLMAgentExecutor",
+    "PromptBuilder",
+    "LLMInferenceEngine",
+    "RefinementLoop",
+    "LLMOutputSchema",
+]

--- a/src/decision/agent_executor.py
+++ b/src/decision/agent_executor.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+from src.inference.cit_controller import CITController
+
+from .prompt_builder import PromptBuilder
+from .inference_engine import LLMInferenceEngine
+from .refinement_loop import RefinementLoop
+from .output_schema import LLMOutputSchema
+
+
+class ExecutionContext(BaseModel):
+    """Carry task context and session metadata."""
+
+    task_context: Dict[str, Any]
+    session_id: str
+
+
+class LLMAgentExecutor:
+    """Orchestrate prompt building, inference and refinement."""
+
+    def __init__(
+        self,
+        builder: PromptBuilder,
+        engine: LLMInferenceEngine,
+        refine_loop: Optional[RefinementLoop] = None,
+        cit_controller: Optional[CITController] = None,
+        version_id: str = "v0",
+    ) -> None:
+        self.builder = builder
+        self.engine = engine
+        self.refine_loop = refine_loop or RefinementLoop()
+        self.cit_controller = cit_controller
+        self.version_id = version_id
+
+    async def execute(self, context: ExecutionContext) -> LLMOutputSchema:
+        prompt = self.builder.build(context.task_context)
+        prompt, rounds = await self.refine_loop.refine(prompt)
+        result = await self.engine.infer(prompt)
+
+        if self.cit_controller is not None:
+            await self.cit_controller.check_pair(
+                prompt,
+                prompt,
+                task_id=context.session_id,
+            )
+
+        action_plan: Dict[str, Any] = {}
+        try:
+            action_plan = json.loads(result.text)
+        except Exception:
+            pass
+
+        metadata = {
+            "version_id": self.version_id,
+            "refinement_rounds": rounds,
+        }
+        return LLMOutputSchema(
+            action_plan=action_plan,
+            llm_output=result.text,
+            metadata=metadata,
+        )
+
+
+__all__ = ["ExecutionContext", "LLMAgentExecutor"]

--- a/src/decision/inference_engine.py
+++ b/src/decision/inference_engine.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from src.inference.llm_agent import LLMAgent, PromptInput, PromptOutput
+
+
+class LLMInferenceEngine:
+    """Simple wrapper around :class:`LLMAgent` for inference."""
+
+    def __init__(
+        self, agent: LLMAgent, model_id: Optional[str] = None
+    ) -> None:
+        self.agent = agent
+        self.model_id = model_id
+
+    async def infer(self, prompt: str) -> PromptOutput:
+        return await self.agent.run(
+            PromptInput(prompt=prompt),
+            model_id=self.model_id,
+        )
+
+
+__all__ = ["LLMInferenceEngine"]

--- a/src/decision/output_schema.py
+++ b/src/decision/output_schema.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+from pydantic import BaseModel, Field
+
+
+class LLMOutputSchema(BaseModel):
+    """Standard output from :class:`LLMAgentExecutor`."""
+
+    action_plan: Dict[str, Any] = Field(default_factory=dict)
+    llm_output: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = ["LLMOutputSchema"]

--- a/src/decision/prompt_builder.py
+++ b/src/decision/prompt_builder.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+class PromptBuilder:
+    """Construct prompts from task context."""
+
+    def __init__(self, template: str | None = None) -> None:
+        self.template = template or "Task context:\n{context}"
+
+    def build(self, task_context: Dict[str, Any]) -> str:
+        context = json.dumps(task_context, ensure_ascii=False)
+        return self.template.format(context=context)
+
+
+__all__ = ["PromptBuilder"]

--- a/src/decision/refinement_loop.py
+++ b/src/decision/refinement_loop.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from src.inference.self_refiner import SelfRefiner
+
+
+class RefinementLoop:
+    """Wrapper to refine prompts using :class:`SelfRefiner`."""
+
+    def __init__(self, refiner: Optional[SelfRefiner] = None) -> None:
+        self.refiner = refiner
+
+    async def refine(self, prompt: str) -> Tuple[str, int]:
+        if self.refiner is None:
+            return prompt, 0
+        session = await self.refiner.refine(prompt)
+        refined = session.final_output or session.initial_output
+        return refined, len(session.steps)
+
+
+__all__ = ["RefinementLoop"]

--- a/tests/unit/test_agent_executor.py
+++ b/tests/unit/test_agent_executor.py
@@ -1,0 +1,113 @@
+import os
+import sys
+from contextlib import contextmanager
+import types
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))  # noqa: E402
+sys.path.insert(0, PROJECT_ROOT)
+
+import pytest  # noqa: E402
+
+from src.decision import (  # noqa: E402
+    ExecutionContext,
+    LLMAgentExecutor,
+    PromptBuilder,
+    LLMInferenceEngine,
+    RefinementLoop,
+)
+from src.decision.output_schema import LLMOutputSchema  # noqa: E402
+from src.inference.llm_agent import (  # noqa: E402
+    LLMAgent,
+    LLMModelRegistry,
+    PromptInput,
+    PromptOutput,
+)
+
+# Patch trace logging like other tests
+from src.core import global_logger as gl  # noqa: E402
+from src.core import trace_logger as tl  # noqa: E402
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.events = []
+
+    def log_event(self, event) -> None:
+        self.events.append(event)
+
+
+@contextmanager
+def log_node_execution(
+    logger,
+    node_name,
+    version,
+    governance_tags=None,
+    input_hash=None,
+):
+    event = types.SimpleNamespace(
+        node_name=node_name,
+        version=version,
+        output_hash=None,
+    )
+    try:
+        yield event
+    finally:
+        logger.log_event(event)
+
+
+@pytest.fixture(autouse=True)
+def _patch_loggers(monkeypatch):
+    dummy = DummyLogger()
+    monkeypatch.setattr(gl, "trace_logger", dummy)
+    monkeypatch.setattr(tl, "log_node_execution", log_node_execution)
+    yield
+
+
+class DummyModel:
+    def __init__(self, reply: str) -> None:
+        self.model_id = "dummy"
+        self.reply = reply
+
+    async def generate(
+        self, prompt: PromptInput, stream: bool = False
+    ) -> PromptOutput:
+        return PromptOutput(text=self.reply, model_id=self.model_id)
+
+
+@pytest.mark.asyncio
+async def test_basic_execution():
+    registry = LLMModelRegistry()
+    registry.register("d", DummyModel('{"type": "noop"}'))
+    agent = LLMAgent(registry, default_model_id="d")
+
+    builder = PromptBuilder()
+    engine = LLMInferenceEngine(agent)
+    executor = LLMAgentExecutor(builder, engine, version_id="v1")
+
+    context = ExecutionContext(task_context={"a": 1}, session_id="s")
+    output = await executor.execute(context)
+    assert isinstance(output, LLMOutputSchema)
+    assert output.action_plan["type"] == "noop"
+    assert output.metadata["version_id"] == "v1"
+
+
+@pytest.mark.asyncio
+async def test_refinement_limit(monkeypatch):
+    registry = LLMModelRegistry()
+    registry.register("d", DummyModel("final"))
+    agent = LLMAgent(registry, default_model_id="d")
+
+    builder = PromptBuilder()
+    engine = LLMInferenceEngine(agent)
+    loop = RefinementLoop()
+
+    async def fake_refine(prompt: str):
+        return "refined", 1
+
+    monkeypatch.setattr(loop, "refine", fake_refine)
+    executor = LLMAgentExecutor(builder, engine, refine_loop=loop)
+
+    context = ExecutionContext(task_context={}, session_id="s")
+    output = await executor.execute(context)
+    assert output.metadata["refinement_rounds"] == 1


### PR DESCRIPTION
## Summary
- implement decision layer with LLMAgentExecutor and helper classes
- export new classes in decision package
- add unit tests for LLMAgentExecutor

## Testing
- `flake8 src/decision tests/unit/test_agent_executor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a27305348832f928da37c5e057a46