### PR TITLE
Implement CITController module

### DIFF
--- a/configs/decision/cit_config.yaml
+++ b/configs/decision/cit_config.yaml
@@ -1,0 +1,3 @@
+embedding_threshold: 0.3
+max_variants: 2
+log_path: data/replay/cit_decision.jsonl

--- a/configs/decision/prompt_templates.yaml
+++ b/configs/decision/prompt_templates.yaml
@@ -1,0 +1,4 @@
+synonyms:
+  block: [restrict, prevent]
+  outbound: [outgoing]
+  traffic: [connections]

--- a/src/decision/__init__.py
+++ b/src/decision/__init__.py
@@ -5,6 +5,15 @@ from .prompt_builder import PromptBuilder
 from .inference_engine import LLMInferenceEngine
 from .refinement_loop import RefinementLoop
 from .output_schema import LLMOutputSchema
+from .cit import (
+    CITController,
+    CITConfig,
+    PromptVariationGenerator,
+    InstructionEmbedder,
+    SemanticDriftEvaluator,
+    ConsistencyReporter,
+    RiskTriggerRouter,
+)
 
 __all__ = [
     "ExecutionContext",
@@ -13,4 +22,11 @@ __all__ = [
     "LLMInferenceEngine",
     "RefinementLoop",
     "LLMOutputSchema",
+    "CITController",
+    "CITConfig",
+    "PromptVariationGenerator",
+    "InstructionEmbedder",
+    "SemanticDriftEvaluator",
+    "ConsistencyReporter",
+    "RiskTriggerRouter",
 ]

--- a/src/decision/cit/__init__.py
+++ b/src/decision/cit/__init__.py
@@ -1,0 +1,18 @@
+"""Contrastive Instruction Tuning utilities."""
+
+from .controller import CITController, CITConfig
+from .prompt_variation import PromptVariationGenerator
+from .embedding import InstructionEmbedder
+from .drift_evaluator import SemanticDriftEvaluator
+from .reporter import ConsistencyReporter
+from .trigger import RiskTriggerRouter
+
+__all__ = [
+    "CITController",
+    "CITConfig",
+    "PromptVariationGenerator",
+    "InstructionEmbedder",
+    "SemanticDriftEvaluator",
+    "ConsistencyReporter",
+    "RiskTriggerRouter",
+]

--- a/src/decision/cit/controller.py
+++ b/src/decision/cit/controller.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Optional, List
+import yaml
+
+from pydantic import BaseModel
+
+from ..inference_engine import LLMInferenceEngine
+from .prompt_variation import PromptVariationGenerator
+from .embedding import InstructionEmbedder
+from .drift_evaluator import SemanticDriftEvaluator
+from .reporter import ConsistencyReporter
+from .trigger import RiskTriggerRouter
+
+
+class CITConfig(BaseModel):
+    embedding_threshold: float = 0.3
+    max_variants: int = 2
+    log_path: str = "data/replay/cit_decision.jsonl"
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "CITConfig":
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            return cls(**data)
+        return cls()
+
+
+class CITController:
+    """Controller to evaluate semantic consistency across prompt variants."""
+
+    def __init__(
+        self,
+        engine: LLMInferenceEngine,
+        config: Optional[CITConfig] = None,
+        variation_gen: Optional[PromptVariationGenerator] = None,
+        embedder: Optional[InstructionEmbedder] = None,
+        evaluator: Optional[SemanticDriftEvaluator] = None,
+        reporter: Optional[ConsistencyReporter] = None,
+        trigger: Optional[RiskTriggerRouter] = None,
+    ) -> None:
+        self.engine = engine
+        self.config = config or CITConfig.from_yaml(
+            "configs/decision/cit_config.yaml"
+        )
+        self.variation_gen = variation_gen or PromptVariationGenerator(
+            "configs/decision/prompt_templates.yaml"
+        )
+        embedder = embedder or InstructionEmbedder()
+        self.evaluator = evaluator or SemanticDriftEvaluator(embedder)
+        self.reporter = reporter or ConsistencyReporter(self.config.log_path)
+        self.trigger = trigger or RiskTriggerRouter(
+            self.config.embedding_threshold
+        )
+
+    async def check(self, prompt: str, task_id: str) -> dict:
+        variants = self.variation_gen.generate(
+            prompt, self.config.max_variants
+        )
+        prompts: List[str] = [prompt] + variants
+        outputs = []
+        for p in prompts:
+            result = await self.engine.infer(p)
+            outputs.append(result.text)
+
+        drift = self.evaluator.embedding_drift(outputs)
+        action_sim = self.evaluator.action_similarity(outputs)
+
+        status = (
+            "drift_detected"
+            if drift > self.config.embedding_threshold
+            else "ok"
+        )
+        recommendation = self.trigger.handle(drift)
+        report = {
+            "original_prompt": prompt,
+            "prompt_variants": variants,
+            "embedding_drift_score": drift,
+            "action_similarity_score": action_sim,
+            "status": status,
+            "recommendation": recommendation,
+            "trace_id": (
+                f"cit-{datetime.utcnow().strftime('%Y%m%d')}-{task_id}"
+            ),
+        }
+        self.reporter.report(report)
+        return report

--- a/src/decision/cit/drift_evaluator.py
+++ b/src/decision/cit/drift_evaluator.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Sequence
+
+from .embedding import InstructionEmbedder
+
+
+class SemanticDriftEvaluator:
+    """Compute similarity and drift between outputs."""
+
+    def __init__(self, embedder: InstructionEmbedder | None = None) -> None:
+        self.embedder = embedder or InstructionEmbedder()
+
+    @staticmethod
+    def _jaccard(a: set[str], b: set[str]) -> float:
+        if not a and not b:
+            return 1.0
+        if not a or not b:
+            return 0.0
+        return len(a & b) / len(a | b)
+
+    def embedding_drift(self, outputs: Sequence[str]) -> float:
+        """Return 1 - average Jaccard similarity across outputs."""
+        if len(outputs) < 2:
+            return 0.0
+        embeds = [self.embedder.embed(o) for o in outputs]
+        sims = [
+            self._jaccard(embeds[i], embeds[j])
+            for i, j in combinations(range(len(embeds)), 2)
+        ]
+        if not sims:
+            return 0.0
+        return 1 - sum(sims) / len(sims)
+
+    def action_similarity(self, outputs: Sequence[str]) -> float:
+        """Return average Jaccard similarity across outputs."""
+        if len(outputs) < 2:
+            return 1.0
+        embeds = [self.embedder.embed(o) for o in outputs]
+        sims = [
+            self._jaccard(embeds[i], embeds[j])
+            for i, j in combinations(range(len(embeds)), 2)
+        ]
+        return sum(sims) / len(sims)

--- a/src/decision/cit/embedding.py
+++ b/src/decision/cit/embedding.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class InstructionEmbedder:
+    """Simple token based embedder."""
+
+    @staticmethod
+    def embed(text: str) -> set[str]:
+        return set(text.lower().split())

--- a/src/decision/cit/prompt_variation.py
+++ b/src/decision/cit/prompt_variation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import yaml
+from typing import Dict, List, Optional
+
+
+class PromptVariationGenerator:
+    """Generate semantically equivalent prompt variants."""
+
+    def __init__(
+        self,
+        template_path: str | None = None,
+        synonyms: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        self.synonyms = synonyms if synonyms is not None else {}
+        if template_path and os.path.exists(template_path):
+            with open(template_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+                self.synonyms.update(data.get("synonyms", {}))
+
+    def generate(self, prompt: str, num_variants: int = 2) -> List[str]:
+        words = prompt.split()
+        variants = []
+        for _ in range(num_variants):
+            new_words = []
+            for w in words:
+                lw = w.lower()
+                if lw in self.synonyms:
+                    repl = self.synonyms[lw][0]
+                    if w.istitle():
+                        repl = repl.capitalize()
+                    new_words.append(repl)
+                else:
+                    new_words.append(w)
+            variants.append(" ".join(new_words))
+        return variants

--- a/src/decision/cit/reporter.py
+++ b/src/decision/cit/reporter.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict
+
+
+class ConsistencyReporter:
+    """Persist CIT results to a JSONL file."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def report(self, data: Dict) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(data) + "\n")

--- a/src/decision/cit/trigger.py
+++ b/src/decision/cit/trigger.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class RiskTriggerRouter:
+    """Decide follow-up action based on drift score."""
+
+    def __init__(self, threshold: float) -> None:
+        self.threshold = threshold
+
+    def handle(self, drift_score: float) -> str:
+        if drift_score > self.threshold:
+            return "refine_and_retry"
+        return "accept"

--- a/tests/integration/test_decision_stability.py
+++ b/tests/integration/test_decision_stability.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import types
+from contextlib import contextmanager
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+import pytest  # noqa: E402
+
+from src.decision.cit import (  # noqa: E402
+    CITController,
+    CITConfig,
+    PromptVariationGenerator,
+)
+from src.decision.inference_engine import LLMInferenceEngine  # noqa: E402
+from src.inference.llm_agent import (  # noqa: E402
+    LLMAgent,
+    LLMModelRegistry,
+    PromptInput,
+    PromptOutput,
+)
+from src.core import global_logger as gl  # noqa: E402
+from src.core import trace_logger as tl  # noqa: E402
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.events = []
+
+    def log_event(self, event) -> None:
+        self.events.append(event)
+
+
+@contextmanager
+def log_node_execution(
+    logger, node_name, version, governance_tags=None, input_hash=None
+):
+    event = types.SimpleNamespace(
+        node_name=node_name, version=version, output_hash=None
+    )
+    try:
+        yield event
+    finally:
+        logger.log_event(event)
+
+
+@pytest.fixture(autouse=True)
+def _patch_loggers(monkeypatch):
+    dummy = DummyLogger()
+    monkeypatch.setattr(gl, "trace_logger", dummy)
+    monkeypatch.setattr(tl, "log_node_execution", log_node_execution)
+    yield
+
+
+class DummyModel:
+    def __init__(self, replies):
+        self.model_id = "d"
+        self.replies = list(replies)
+
+    async def generate(
+        self, prompt: PromptInput, stream: bool = False
+    ) -> PromptOutput:
+        text = self.replies.pop(0)
+        return PromptOutput(text=text, model_id=self.model_id)
+
+
+@pytest.mark.asyncio
+async def test_decision_stability(monkeypatch):
+    registry = LLMModelRegistry()
+    registry.register("d", DummyModel(["same", "same", "same"]))
+    agent = LLMAgent(registry, default_model_id="d")
+    engine = LLMInferenceEngine(agent)
+
+    gen = PromptVariationGenerator(synonyms={"block": ["prevent"]})
+    cfg = CITConfig(embedding_threshold=0.5, max_variants=2)
+    controller = CITController(engine, config=cfg, variation_gen=gen)
+
+    report = await controller.check("block", task_id="t")
+    assert report["status"] == "ok"
+    assert len(report["prompt_variants"]) == 2

--- a/tests/unit/test_drift_evaluator.py
+++ b/tests/unit/test_drift_evaluator.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.decision.cit.embedding import InstructionEmbedder  # noqa: E402
+from src.decision.cit.drift_evaluator import (  # noqa: E402
+    SemanticDriftEvaluator,
+)
+
+
+def test_drift_evaluator():
+    evaluator = SemanticDriftEvaluator(InstructionEmbedder())
+    drift = evaluator.embedding_drift(["a b", "a b"])
+    assert drift == 0.0
+    sim = evaluator.action_similarity(["a b", "a c"])
+    assert 0.0 <= sim <= 1.0

--- a/tests/unit/test_prompt_variation.py
+++ b/tests/unit/test_prompt_variation.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.decision.cit.prompt_variation import (  # noqa: E402
+    PromptVariationGenerator,
+)
+
+
+def test_prompt_variation_basic():
+    gen = PromptVariationGenerator(
+        synonyms={"block": ["prevent"], "traffic": ["connections"]}
+    )
+    variants = gen.generate("Block traffic", num_variants=1)
+    assert variants[0] == "Prevent connections"


### PR DESCRIPTION
## Summary
- add Contrastive Instruction Tuning controller under decision layer
- log thresholds and synonym templates for prompt generation
- expose CIT utilities via decision package
- implement unit and integration tests for CIT components

## Testing
- `flake8 src/decision/cit tests/unit/test_prompt_variation.py tests/unit/test_drift_evaluator.py tests/integration/test_decision_stability.py src/decision/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad5f4c6fc832f89313f9dc310a438