### PR TITLE
Add SOARGenerator module

### DIFF
--- a/configs/soar/soar_config.yaml
+++ b/configs/soar/soar_config.yaml
@@ -1,0 +1,1 @@
+platform: stackstorm

--- a/configs/soar/templates/stackstorm.yaml.j2
+++ b/configs/soar/templates/stackstorm.yaml.j2
@@ -1,0 +1,12 @@
+name: {{ name }}
+actions:
+{% for action in actions %}
+  - name: {{ action.name }}
+    ref: {{ action.ref }}
+    parameters:
+{% for key, val in parameters.items() %}
+      {{ key }}: {{ val }}
+{% endfor %}
+{% endfor %}
+metadata:
+  generated_by: asda-x-agent

--- a/src/decision/__init__.py
+++ b/src/decision/__init__.py
@@ -14,6 +14,13 @@ from .cit import (
     ConsistencyReporter,
     RiskTriggerRouter,
 )
+from .soar import (
+    SOARGenerator,
+    PlaybookBuilder,
+    ActionParameterMapper,
+    OutputValidator,
+    VersionTagger,
+)
 
 __all__ = [
     "ExecutionContext",
@@ -29,4 +36,9 @@ __all__ = [
     "SemanticDriftEvaluator",
     "ConsistencyReporter",
     "RiskTriggerRouter",
+    "SOARGenerator",
+    "PlaybookBuilder",
+    "ActionParameterMapper",
+    "OutputValidator",
+    "VersionTagger",
 ]

--- a/src/decision/soar/__init__.py
+++ b/src/decision/soar/__init__.py
@@ -1,0 +1,15 @@
+"""SOAR generation utilities."""
+
+from .generator import SOARGenerator
+from .builder import PlaybookBuilder
+from .mapper import ActionParameterMapper
+from .validator import OutputValidator
+from .versioning import VersionTagger
+
+__all__ = [
+    "SOARGenerator",
+    "PlaybookBuilder",
+    "ActionParameterMapper",
+    "OutputValidator",
+    "VersionTagger",
+]

--- a/src/decision/soar/builder.py
+++ b/src/decision/soar/builder.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+class PlaybookBuilder:
+    """Render playbook templates into dictionaries."""
+
+    def __init__(
+        self, platform: str = "stackstorm", template_dir: str | None = None
+    ) -> None:
+        self.platform = platform
+        self.template_dir = Path(template_dir or "configs/soar/templates")
+        self.env = Environment(
+            loader=FileSystemLoader(str(self.template_dir)),
+            autoescape=select_autoescape()
+        )
+
+    def build(
+        self, template_name: str, context: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        template = self.env.get_template(template_name)
+        rendered = template.render(**context)
+        return yaml.safe_load(rendered)

--- a/src/decision/soar/generator.py
+++ b/src/decision/soar/generator.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .builder import PlaybookBuilder
+from .mapper import ActionParameterMapper
+from .validator import OutputValidator
+from .versioning import VersionTagger
+
+
+class SOARGenerator:
+    """Convert semantic decisions into SOAR playbooks."""
+
+    def __init__(self, platform: str = "stackstorm") -> None:
+        self.platform = platform
+        self.builder = PlaybookBuilder(platform)
+        self.mapper = ActionParameterMapper()
+        self.validator = OutputValidator()
+        self.versioner = VersionTagger()
+
+    def generate(
+        self, decision: Dict[str, Any], template: str
+    ) -> Dict[str, Any]:
+        params = self.mapper.map_parameters(decision)
+        context = {
+            "name": decision.get("name", "generated-playbook"),
+            "actions": decision.get("actions", []),
+            "parameters": params,
+        }
+        playbook = self.builder.build(template, context)
+        self.validator.validate(playbook)
+        return self.versioner.tag(playbook)

--- a/src/decision/soar/mapper.py
+++ b/src/decision/soar/mapper.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class ActionParameterMapper:
+    """Map decision data to playbook parameters."""
+
+    def map_parameters(self, decision: Dict[str, Any]) -> Dict[str, Any]:
+        # In a real implementation this would be more complex
+        return decision.get("parameters", {})

--- a/src/decision/soar/validator.py
+++ b/src/decision/soar/validator.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from jsonschema import Draft7Validator, ValidationError
+
+
+BASIC_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "actions": {"type": "array"},
+    },
+    "required": ["name", "actions"],
+}
+
+
+class OutputValidator:
+    """Validate generated playbooks."""
+
+    def __init__(self, schema: Dict[str, Any] | None = None) -> None:
+        self.schema = schema or BASIC_SCHEMA
+        self.validator = Draft7Validator(self.schema)
+
+    def validate(self, playbook: Dict[str, Any]) -> None:
+        errors = sorted(
+            self.validator.iter_errors(playbook), key=lambda e: e.path
+        )
+        if errors:
+            raise ValidationError(errors[0])

--- a/src/decision/soar/versioning.py
+++ b/src/decision/soar/versioning.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import uuid
+from hashlib import sha256
+from typing import Any, Dict
+
+
+class VersionTagger:
+    """Add version metadata to playbooks."""
+
+    def tag(self, playbook: Dict[str, Any]) -> Dict[str, Any]:
+        version = uuid.uuid4().hex
+        pb_bytes = str(playbook).encode("utf-8")
+        checksum = sha256(pb_bytes).hexdigest()
+        playbook.setdefault("metadata", {})
+        playbook["metadata"].update({"version": version, "checksum": checksum})
+        return playbook

--- a/tests/integration/test_decision_to_playbook.py
+++ b/tests/integration/test_decision_to_playbook.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.decision.soar import SOARGenerator  # noqa: E402
+
+
+def test_full_flow():
+    decision = {
+        "name": "isolate-host-1",
+        "actions": [{"name": "iso", "ref": "net.block"}],
+        "parameters": {"target_ip": "1.1.1.1"},
+    }
+    gen = SOARGenerator()
+    pb = gen.generate(decision, template="stackstorm.yaml.j2")
+    assert pb["actions"][0]["ref"] == "net.block"

--- a/tests/unit/test_playbook_validation.py
+++ b/tests/unit/test_playbook_validation.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+import pytest  # noqa: E402
+from jsonschema import ValidationError  # noqa: E402
+from src.decision.soar import OutputValidator  # noqa: E402
+
+
+def test_validator_passes():
+    validator = OutputValidator()
+    valid_pb = {"name": "test", "actions": []}
+    validator.validate(valid_pb)
+
+
+def test_validator_fails():
+    validator = OutputValidator()
+    invalid_pb = {"actions": []}
+    with pytest.raises(ValidationError):
+        validator.validate(invalid_pb)

--- a/tests/unit/test_soar_generator.py
+++ b/tests/unit/test_soar_generator.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.decision.soar import SOARGenerator  # noqa: E402
+
+
+def test_generate_stackstorm_playbook(tmp_path):
+    decision = {
+        "name": "isolate-host-10-1-2-3",
+        "actions": [
+            {"name": "isolate_host", "ref": "network.firewall.block"}
+        ],
+        "parameters": {"target_ip": "10.1.2.3", "duration": 1800},
+    }
+    gen = SOARGenerator(platform="stackstorm")
+    playbook = gen.generate(decision, template="stackstorm.yaml.j2")
+    assert playbook["name"] == decision["name"]
+    assert playbook["actions"][0]["name"] == "isolate_host"
+    assert playbook["metadata"]["generated_by"] == "asda-x-agent"
+    assert "version" in playbook["metadata"]


### PR DESCRIPTION
## Summary
- implement `SOARGenerator` for converting decisions to playbooks
- add Playbook builder, mapper, validator and version tagger
- include basic stackstorm template and config
- provide unit and integration tests

## Testing
- `flake8 src/decision/soar src/decision/__init__.py tests/unit/test_soar_generator.py tests/unit/test_playbook_validation.py tests/integration/test_decision_to_playbook.py`
- `pytest tests/unit/test_soar_generator.py tests/unit/test_playbook_validation.py tests/integration/test_decision_to_playbook.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688adfaa1274832fbfc042f9d6bfe6d7