### PR TITLE
Implement VersionedActionAudit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,5 @@ Werkzeug==3.1.3
 wrapt==1.17.2
 xxhash==3.5.0
 zstandard==0.23.0
+networkx==3.5
+deepdiff==8.5.0

--- a/src/decision/__init__.py
+++ b/src/decision/__init__.py
@@ -21,6 +21,14 @@ from .soar import (
     OutputValidator,
     VersionTagger,
 )
+from .versioning import (
+    VersionedActionAudit,
+    VersionIDGenerator,
+    ActionTraceLogger,
+    DecisionDiffer,
+    AuditStoreManager,
+    ASGAInterface,
+)
 
 __all__ = [
     "ExecutionContext",
@@ -41,4 +49,10 @@ __all__ = [
     "ActionParameterMapper",
     "OutputValidator",
     "VersionTagger",
+    "VersionedActionAudit",
+    "VersionIDGenerator",
+    "ActionTraceLogger",
+    "DecisionDiffer",
+    "AuditStoreManager",
+    "ASGAInterface",
 ]

--- a/src/decision/versioning/__init__.py
+++ b/src/decision/versioning/__init__.py
@@ -1,0 +1,15 @@
+from .audit_logger import VersionedActionAudit
+from .version_id import VersionIDGenerator
+from .trace_builder import ActionTraceLogger
+from .diff_engine import DecisionDiffer
+from .store import AuditStoreManager
+from .asga_hook import ASGAInterface
+
+__all__ = [
+    "VersionedActionAudit",
+    "VersionIDGenerator",
+    "ActionTraceLogger",
+    "DecisionDiffer",
+    "AuditStoreManager",
+    "ASGAInterface",
+]

--- a/src/decision/versioning/asga_hook.py
+++ b/src/decision/versioning/asga_hook.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class ASGAInterface:
+    """Placeholder interface to governance subsystem."""
+
+    def report(self, record: Dict[str, Any]) -> None:  # pragma: no cover
+        # In real usage this would send the record to the governance system
+        pass

--- a/src/decision/versioning/audit_logger.py
+++ b/src/decision/versioning/audit_logger.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from .version_id import VersionIDGenerator
+from .trace_builder import ActionTraceLogger
+from .diff_engine import DecisionDiffer
+from .store import AuditStoreManager
+from .asga_hook import ASGAInterface
+
+
+@dataclass
+class VersionedActionAudit:
+    """Main entry for recording versioned decisions."""
+
+    store: AuditStoreManager
+    id_gen: VersionIDGenerator = field(default_factory=VersionIDGenerator)
+    tracer: ActionTraceLogger = field(default_factory=ActionTraceLogger)
+    differ: DecisionDiffer = field(default_factory=DecisionDiffer)
+    asga: Optional[ASGAInterface] = None
+    last_version: Optional[str] = None
+
+    def record(self, decision: Dict[str, Any]) -> str:
+        """Record a decision and return its version id."""
+        version_id = self.id_gen.generate(decision)
+        diff: Dict[str, Any] = {}
+        if self.last_version is not None:
+            parent = self.store.load(self.last_version)
+            if parent is not None:
+                diff = self.differ.compare(parent.get("action_plan"), decision)
+        record = {
+            "version_id": version_id,
+            "parent_version": self.last_version,
+            "action_plan": decision,
+            "diff_from_parent": diff,
+        }
+        self.store.save(version_id, record)
+        self.tracer.add_version(record)
+        if self.asga is not None:
+            self.asga.report(record)
+        self.last_version = version_id
+        return version_id

--- a/src/decision/versioning/diff_engine.py
+++ b/src/decision/versioning/diff_engine.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from deepdiff import DeepDiff
+
+
+class DecisionDiffer:
+    """Compare two decision dictionaries."""
+
+    def compare(self, old: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
+        diff = DeepDiff(old or {}, new or {}, verbose_level=2)
+        return diff.to_dict()

--- a/src/decision/versioning/store.py
+++ b/src/decision/versioning/store.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+
+class AuditStoreManager:
+    """Persist versioned records as JSON files."""
+
+    def __init__(self, root: str = "storage/versioned_decisions") -> None:
+        self.root = root
+        os.makedirs(self.root, exist_ok=True)
+
+    def _path(self, version_id: str) -> str:
+        return os.path.join(self.root, f"{version_id}.json")
+
+    def save(self, version_id: str, record: Dict[str, Any]) -> None:
+        with open(self._path(version_id), "w", encoding="utf-8") as f:
+            json.dump(record, f)
+
+    def load(self, version_id: str) -> Optional[Dict[str, Any]]:
+        path = self._path(version_id)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/src/decision/versioning/trace_builder.py
+++ b/src/decision/versioning/trace_builder.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import networkx as nx
+from typing import Any, Dict
+
+
+class ActionTraceLogger:
+    """Maintain a DAG of decision versions."""
+
+    def __init__(self) -> None:
+        self.graph = nx.DiGraph()
+
+    def add_version(self, record: Dict[str, Any]) -> None:
+        vid = record["version_id"]
+        self.graph.add_node(vid, **record)
+        parent = record.get("parent_version")
+        if parent:
+            self.graph.add_edge(parent, vid)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return nx.node_link_data(self.graph)

--- a/src/decision/versioning/version_id.py
+++ b/src/decision/versioning/version_id.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import uuid
+from hashlib import sha256
+from typing import Any, Dict
+
+
+class VersionIDGenerator:
+    """Generate deterministic version ids from decision content."""
+
+    def generate(self, decision: Dict[str, Any]) -> str:
+        """Return a unique version id string."""
+        content = str(sorted(decision.items())).encode("utf-8")
+        checksum = sha256(content).hexdigest()[:8]
+        return f"v{uuid.uuid4().hex[:8]}-{checksum}"

--- a/tests/unit/test_version_audit.py
+++ b/tests/unit/test_version_audit.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.decision.versioning import (
+    VersionIDGenerator,
+    DecisionDiffer,
+    AuditStoreManager,
+    VersionedActionAudit,
+)
+
+
+def test_version_id_uniqueness():
+    gen = VersionIDGenerator()
+    d1 = gen.generate({"a": 1})
+    d2 = gen.generate({"a": 1})
+    assert d1 != d2
+
+
+def test_decision_differ():
+    diff = DecisionDiffer().compare({"a": 1}, {"a": 2})
+    assert "values_changed" in diff
+
+
+def test_store_round_trip(tmp_path):
+    store = AuditStoreManager(root=str(tmp_path))
+    store.save("v1", {"foo": 1})
+    assert store.load("v1") == {"foo": 1}
+
+
+def test_trace_logger_and_audit(tmp_path):
+    store = AuditStoreManager(root=str(tmp_path))
+    audit = VersionedActionAudit(store=store)
+    v1 = audit.record({"act": "a"})
+    v2 = audit.record({"act": "b"})
+    graph = audit.tracer.graph
+    assert graph.has_edge(v1, v2)


### PR DESCRIPTION
## Summary
- add VersionedActionAudit framework in `src/decision/versioning`
- expose new versioning classes via decision layer init
- add dependencies for `networkx` and `deepdiff`
- test core versioning components

## Testing
- `flake8 src | head`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ae80caac0832fba7da8231ed83c20