### PR TITLE
Add ActionDispatcher module

### DIFF
--- a/configs/execution/dispatch_rules.yaml
+++ b/configs/execution/dispatch_rules.yaml
@@ -1,0 +1,6 @@
+low:
+  default: auto
+medium:
+  default: hitl
+high:
+  default: block

--- a/configs/execution/risk_thresholds.yaml
+++ b/configs/execution/risk_thresholds.yaml
@@ -1,0 +1,3 @@
+low: 0.3
+medium: 0.6
+high: 0.9

--- a/src/execution/dispatcher/__init__.py
+++ b/src/execution/dispatcher/__init__.py
@@ -1,0 +1,15 @@
+from .dispatcher import ActionDispatcher
+from .rules import DispatchRuleEngine
+from .auto_trigger import AutoExecutionTrigger
+from .hitl_router import HITLRouter
+from .interlock import EmergencyInterlock
+from .logger import DispatchAuditLogger
+
+__all__ = [
+    "ActionDispatcher",
+    "DispatchRuleEngine",
+    "AutoExecutionTrigger",
+    "HITLRouter",
+    "EmergencyInterlock",
+    "DispatchAuditLogger",
+]

--- a/src/execution/dispatcher/auto_trigger.py
+++ b/src/execution/dispatcher/auto_trigger.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class AutoExecutionTrigger:
+    """Placeholder for automatic execution interface."""
+
+    def execute(self, action_plan: Dict[str, Any]) -> None:
+        # In production this would call AutoExecutor or similar
+        pass
+
+
+__all__ = ["AutoExecutionTrigger"]

--- a/src/execution/dispatcher/dispatcher.py
+++ b/src/execution/dispatcher/dispatcher.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from .rules import DispatchRuleEngine
+from .auto_trigger import AutoExecutionTrigger
+from .hitl_router import HITLRouter
+from .interlock import EmergencyInterlock
+from .logger import DispatchAuditLogger, DispatchRecord
+
+
+class ActionDispatcher:
+    """Route actions to execution paths based on risk and policy."""
+
+    def __init__(
+        self,
+        rule_engine: DispatchRuleEngine | None = None,
+        auto_trigger: AutoExecutionTrigger | None = None,
+        hitl_router: HITLRouter | None = None,
+        interlock: EmergencyInterlock | None = None,
+        logger: DispatchAuditLogger | None = None,
+    ) -> None:
+        self.rule_engine = rule_engine or DispatchRuleEngine()
+        self.auto_trigger = auto_trigger or AutoExecutionTrigger()
+        self.hitl_router = hitl_router or HITLRouter()
+        self.interlock = interlock or EmergencyInterlock()
+        self.logger = logger or DispatchAuditLogger()
+
+    def dispatch(
+        self,
+        decision_id: str,
+        action_plan: Dict[str, Any],
+        risk_level: str,
+        action_type: str,
+        confidence: float,
+        trace_id: str,
+    ) -> DispatchRecord:
+        """Dispatch an action plan based on rules and risk."""
+
+        route = self.rule_engine.decide(risk_level, action_type, confidence)
+        executed = False
+        rationale = ""
+
+        if route == "auto":
+            self.auto_trigger.execute(action_plan)
+            executed = True
+        elif route == "hitl":
+            self.hitl_router.send(action_plan)
+        elif route == "block":
+            self.interlock.block(action_plan)
+            rationale = "Blocked due to high risk"
+
+        record = DispatchRecord(
+            decision_id=decision_id,
+            action_plan=action_plan,
+            risk_level=risk_level,
+            dispatch_route=route.upper(),
+            executed=executed,
+            rationale=rationale,
+            trace_id=trace_id,
+            timestamp=datetime.utcnow(),
+        )
+        self.logger.log(record)
+        return record
+
+
+__all__ = ["ActionDispatcher"]

--- a/src/execution/dispatcher/hitl_router.py
+++ b/src/execution/dispatcher/hitl_router.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class HITLRouter:
+    """Send tasks to a Human-In-The-Loop console."""
+
+    def send(self, action_plan: Dict[str, Any]) -> None:
+        # Placeholder for HITL integration
+        pass
+
+
+__all__ = ["HITLRouter"]

--- a/src/execution/dispatcher/interlock.py
+++ b/src/execution/dispatcher/interlock.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class EmergencyInterlock:
+    """Block or freeze high-risk actions."""
+
+    def block(self, action_plan: Dict[str, Any]) -> None:
+        # Placeholder for emergency block action
+        pass
+
+
+__all__ = ["EmergencyInterlock"]

--- a/src/execution/dispatcher/logger.py
+++ b/src/execution/dispatcher/logger.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+
+class DispatchRecord(BaseModel):
+    decision_id: str
+    action_plan: Dict[str, Any]
+    risk_level: str
+    dispatch_route: str
+    executed: bool
+    rationale: str
+    trace_id: str
+    timestamp: datetime
+
+
+class DispatchAuditLogger:
+    """Simple logger writing dispatch records to JSONL."""
+
+    def __init__(self, log_path: str = "data/dispatch_log.jsonl") -> None:
+        self.log_path = log_path
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    def log(self, record: DispatchRecord) -> None:
+        with open(self.log_path, "a", encoding="utf-8") as f:
+            f.write(record.json() + "\n")
+
+
+__all__ = ["DispatchAuditLogger", "DispatchRecord"]

--- a/src/execution/dispatcher/rules.py
+++ b/src/execution/dispatcher/rules.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import yaml
+
+
+class DispatchRuleEngine:
+    """Apply YAML-defined rules to decide dispatch routes."""
+
+    def __init__(
+        self, rule_path: str = "configs/execution/dispatch_rules.yaml"
+    ) -> None:
+        if os.path.exists(rule_path):
+            with open(rule_path, "r", encoding="utf-8") as f:
+                self.rules = yaml.safe_load(f) or {}
+        else:
+            self.rules = {}
+
+    def decide(
+        self, risk_level: str, action_type: str, confidence: float
+    ) -> str:
+        level_rules = self.rules.get(risk_level, {})
+        return level_rules.get(
+            action_type, level_rules.get("default", "hitl")
+        )
+
+
+__all__ = ["DispatchRuleEngine"]

--- a/src/execution/executor_router.py
+++ b/src/execution/executor_router.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .dispatcher import ActionDispatcher, DispatchRecord
+
+
+def route_action(
+    decision_id: str,
+    action_plan: Dict[str, Any],
+    risk_level: str,
+    action_type: str,
+    confidence: float,
+    trace_id: str,
+) -> DispatchRecord:
+    dispatcher = ActionDispatcher()
+    return dispatcher.dispatch(
+        decision_id,
+        action_plan,
+        risk_level,
+        action_type,
+        confidence,
+        trace_id,
+    )
+
+
+__all__ = ["route_action", "ActionDispatcher", "DispatchRecord"]

--- a/tests/integration/test_dispatch_edge_cases.py
+++ b/tests/integration/test_dispatch_edge_cases.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.execution.dispatcher import ActionDispatcher  # noqa: E402
+
+
+def test_high_risk_triggers_block():
+    dispatcher = ActionDispatcher()
+    record = dispatcher.dispatch(
+        decision_id="v1",
+        action_plan={"type": "block_host", "target": "1.1.1.1"},
+        risk_level="high",
+        action_type="block_host",
+        confidence=0.99,
+        trace_id="t1",
+    )
+    assert record.dispatch_route == "BLOCK"

--- a/tests/integration/test_full_execution_path.py
+++ b/tests/integration/test_full_execution_path.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.execution.dispatcher import ActionDispatcher
+from src.execution.dispatcher.logger import DispatchAuditLogger
+
+
+def test_auto_execution_path(tmp_path):
+    log_file = tmp_path / "dispatch.jsonl"
+    dispatcher = ActionDispatcher(logger=DispatchAuditLogger(str(log_file)))
+    record = dispatcher.dispatch(
+        decision_id="v2",
+        action_plan={"type": "echo", "msg": "hi"},
+        risk_level="low",
+        action_type="echo",
+        confidence=0.8,
+        trace_id="t2",
+    )
+    assert record.executed is True
+    assert log_file.exists()

--- a/tests/unit/test_dispatch_rules.py
+++ b/tests/unit/test_dispatch_rules.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.execution.dispatcher import DispatchRuleEngine  # noqa: E402
+
+
+def test_rules_map_to_routes():
+    engine = DispatchRuleEngine("configs/execution/dispatch_rules.yaml")
+    assert engine.decide("low", "block_host", 0.1) == "auto"
+    assert engine.decide("medium", "block_host", 0.5) == "hitl"
+    assert engine.decide("high", "block_host", 0.95) == "block"


### PR DESCRIPTION
## Summary
- implement ActionDispatcher and routing helpers
- add YAML rule configs
- add executor routing entry point
- cover dispatcher logic with unit and integration tests

## Testing
- `flake8 src/execution`
- `pytest -q tests/unit/test_dispatch_rules.py tests/integration/test_dispatch_edge_cases.py tests/integration/test_full_execution_path.py`

------
https://chatgpt.com/codex/tasks/task_e_688af9578a08832fbda3cbb2d9615a12