### PR TITLE
Implement replay memory module

### DIFF
--- a/src/learning/replay/__init__.py
+++ b/src/learning/replay/__init__.py
@@ -1,0 +1,15 @@
+"""Replay memory and simulation utilities."""
+
+from .replay_schema import ReplayEntry
+from .memory_manager import ReplayMemoryManager
+from .simulator import ReplaySimulator
+from .query import ReplayQueryEngine
+from .utils import sort_by_time
+
+__all__ = [
+    "ReplayEntry",
+    "ReplayMemoryManager",
+    "ReplaySimulator",
+    "ReplayQueryEngine",
+    "sort_by_time",
+]

--- a/src/learning/replay/memory_manager.py
+++ b/src/learning/replay/memory_manager.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Persistence layer for replay entries."""
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from typing import Iterator, List, Optional
+
+from .replay_schema import ReplayEntry
+
+
+class ReplayMemoryManager:
+    """Store and retrieve :class:`ReplayEntry` objects."""
+
+    def __init__(self, db_path: str = "data/replay/replay.db") -> None:
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        self.conn.execute(
+            """CREATE TABLE IF NOT EXISTS replay_entries (
+                replay_id TEXT PRIMARY KEY,
+                data TEXT
+            )"""
+        )
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def save_entry(self, entry: ReplayEntry) -> None:
+        """Insert or update a replay entry."""
+        data = entry.model_dump_json()
+        self.conn.execute(
+            "INSERT OR REPLACE INTO replay_entries (replay_id, data) VALUES (?, ?)",
+            (entry.replay_id, data),
+        )
+        self.conn.commit()
+
+    def load_entry(self, replay_id: str) -> ReplayEntry:
+        """Fetch a single entry by id."""
+        cur = self.conn.execute(
+            "SELECT data FROM replay_entries WHERE replay_id=?", (replay_id,)
+        )
+        row = cur.fetchone()
+        if not row:
+            raise KeyError(replay_id)
+        return ReplayEntry.model_validate(json.loads(row[0]))
+
+    def query_entries(self, *, replay_label: Optional[str] = None) -> List[ReplayEntry]:
+        """Retrieve entries optionally filtered by label."""
+        cur = self.conn.execute("SELECT data FROM replay_entries")
+        rows = [ReplayEntry.model_validate(json.loads(r[0])) for r in cur.fetchall()]
+        if replay_label is not None:
+            rows = [r for r in rows if r.replay_label == replay_label]
+        return rows
+
+    @contextmanager
+    def session(self) -> Iterator["ReplayMemoryManager"]:
+        try:
+            yield self
+        finally:
+            self.close()
+
+
+__all__ = ["ReplayMemoryManager"]

--- a/src/learning/replay/query.py
+++ b/src/learning/replay/query.py
@@ -1,0 +1,19 @@
+"""Simple query helpers for replay entries."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .memory_manager import ReplayMemoryManager
+from .replay_schema import ReplayEntry
+
+
+class ReplayQueryEngine:
+    """Filter replay entries by common fields."""
+
+    def __init__(self, manager: ReplayMemoryManager) -> None:
+        self.manager = manager
+
+    def by_label(self, label: str) -> List[ReplayEntry]:
+        """Return entries with the given replay label."""
+        return self.manager.query_entries(replay_label=label)

--- a/src/learning/replay/replay_schema.py
+++ b/src/learning/replay/replay_schema.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Data schema for replay records."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ReplayEntry(BaseModel):
+    """Structured record capturing a single decision episode."""
+
+    replay_id: str = Field(description="Globally unique ID for this replay entry")
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="When the decision occurred",
+    )
+    input_event: Dict[str, Any] = Field(description="Original event data")
+    parsed_prompt: Optional[str] = Field(default=None, description="Normalized prompt")
+    retrieved_knowledge: Optional[List[str]] = Field(
+        default=None, description="RAG chunk identifiers or content"
+    )
+    decision_trace: Optional[Dict[str, Any]] = Field(
+        default=None, description="DAG of the reasoning process"
+    )
+    action_output: Optional[Dict[str, Any]] = Field(
+        default=None, description="Action taken or suggestion produced"
+    )
+    feedback_signal: Optional[str] = Field(
+        default=None, description="Environment feedback after execution"
+    )
+    version_id: Optional[str] = Field(
+        default=None, description="Model or strategy version used"
+    )
+    drift_tag: Optional[str] = Field(default=None, description="Semantic drift tag")
+    replay_label: Optional[str] = Field(
+        default=None, description="User or system classification of this replay"
+    )
+
+
+__all__ = ["ReplayEntry"]

--- a/src/learning/replay/simulator.py
+++ b/src/learning/replay/simulator.py
@@ -1,0 +1,22 @@
+"""Utilities to rebuild prompts and environment for a replay entry."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .replay_schema import ReplayEntry
+
+
+class ReplaySimulator:
+    """Reconstruct execution context from stored replay data."""
+
+    def __init__(self, entry: ReplayEntry) -> None:
+        self.entry = entry
+
+    def build_context(self) -> Dict[str, Any]:
+        """Return a lightweight context dictionary for the replay."""
+        return {
+            "prompt": self.entry.parsed_prompt,
+            "knowledge": self.entry.retrieved_knowledge,
+            "decision_trace": self.entry.decision_trace,
+        }

--- a/src/learning/replay/utils.py
+++ b/src/learning/replay/utils.py
@@ -1,0 +1,12 @@
+"""Helper utilities for replay workflows."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .replay_schema import ReplayEntry
+
+
+def sort_by_time(entries: Iterable[ReplayEntry]) -> List[ReplayEntry]:
+    """Return entries sorted by timestamp."""
+    return sorted(entries, key=lambda e: e.timestamp)

--- a/tests/unit/learning/replay/test_drift_annotation.py
+++ b/tests/unit/learning/replay/test_drift_annotation.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from datetime import datetime, timezone
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.replay import ReplayEntry  # noqa: E402
+
+
+def test_drift_tag_preserved():
+    entry = ReplayEntry(
+        replay_id="d1",
+        timestamp=datetime.now(timezone.utc),
+        input_event={},
+        drift_tag="major",
+    )
+    assert entry.drift_tag == "major"

--- a/tests/unit/learning/replay/test_memory_manager.py
+++ b/tests/unit/learning/replay/test_memory_manager.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.replay import ReplayEntry, ReplayMemoryManager  # noqa: E402
+
+
+def test_save_and_load_entry():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = os.path.join(tmp, "replay.db")
+        manager = ReplayMemoryManager(db)
+        entry = ReplayEntry(
+            replay_id="r1",
+            timestamp=datetime.now(timezone.utc),
+            input_event={"a": 1},
+            replay_label="TP",
+        )
+        manager.save_entry(entry)
+        loaded = manager.load_entry("r1")
+        assert loaded.replay_id == "r1"
+        assert loaded.input_event == {"a": 1}
+
+
+def test_query_by_label():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = os.path.join(tmp, "replay.db")
+        manager = ReplayMemoryManager(db)
+        e1 = ReplayEntry(replay_id="1", timestamp=datetime.now(timezone.utc), input_event={}, replay_label="TP")
+        e2 = ReplayEntry(replay_id="2", timestamp=datetime.now(timezone.utc), input_event={}, replay_label="FP")
+        manager.save_entry(e1)
+        manager.save_entry(e2)
+        results = manager.query_entries(replay_label="TP")
+        assert len(results) == 1
+        assert results[0].replay_id == "1"

--- a/tests/unit/learning/replay/test_replay_integrity.py
+++ b/tests/unit/learning/replay/test_replay_integrity.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.replay import ReplayEntry, ReplayMemoryManager, ReplaySimulator  # noqa: E402
+
+
+def test_integrity_persist_decision_trace():
+    with tempfile.TemporaryDirectory() as tmp:
+        manager = ReplayMemoryManager(os.path.join(tmp, "replay.db"))
+        entry = ReplayEntry(
+            replay_id="r2",
+            timestamp=datetime.now(timezone.utc),
+            input_event={},
+            parsed_prompt="hello",
+            decision_trace={"chain": [1, 2]},
+        )
+        manager.save_entry(entry)
+        loaded = manager.load_entry("r2")
+        sim = ReplaySimulator(loaded)
+        ctx = sim.build_context()
+        assert ctx["prompt"] == "hello"
+        assert ctx["decision_trace"] == {"chain": [1, 2]}


### PR DESCRIPTION
## Summary
- add replay entry schema using pydantic
- implement memory manager with SQLite persistence
- implement simulator, query engine and helper utils
- provide unit tests for replay memory

## Testing
- `pytest tests/unit/learning/replay -q`
- `flake8 src || true`

------
https://chatgpt.com/codex/tasks/task_e_688b7b083cc8832fa711abc7a83bb0a5