### PR TITLE
Add SEC Generator

### DIFF
--- a/src/learning/__init__.py
+++ b/src/learning/__init__.py
@@ -1,1 +1,27 @@
-# learning module
+"""Learning utilities including replay memory and SEC generation."""
+
+from .replay import (
+    ReplayEntry,
+    ReplayMemoryManager,
+    ReplayQueryEngine,
+    ReplaySimulator,
+    sort_by_time,
+)
+from .sec import (
+    SECTask,
+    VersionContext,
+    replay_to_sec,
+    render_template,
+)
+
+__all__ = [
+    "ReplayEntry",
+    "ReplayMemoryManager",
+    "ReplayQueryEngine",
+    "ReplaySimulator",
+    "sort_by_time",
+    "SECTask",
+    "VersionContext",
+    "replay_to_sec",
+    "render_template",
+]

--- a/src/learning/sec/__init__.py
+++ b/src/learning/sec/__init__.py
@@ -1,0 +1,7 @@
+"""Self-Evolving Curriculum task generator."""
+
+from .sec_schema import SECTask, VersionContext
+from .generator import replay_to_sec
+from .templates import render_template
+
+__all__ = ["SECTask", "VersionContext", "replay_to_sec", "render_template"]

--- a/src/learning/sec/generator.py
+++ b/src/learning/sec/generator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Convert replay traces into SEC micro tasks."""
+
+from datetime import datetime
+from typing import Any, Dict
+from uuid import uuid4
+
+from src.learning.replay import ReplayEntry
+
+from .sec_schema import SECTask, VersionContext
+from .templates import render_template
+
+
+CATEGORY_MAP = {
+    "misclassification": "intrusion_categorization",
+    "prompt_injection": "input_sanitation",
+}
+
+
+def _choose_category(replay: ReplayEntry) -> str:
+    """Select task category based on replay label."""
+    label = (replay.replay_label or "").lower()
+    return CATEGORY_MAP.get(label, "intrusion_categorization")
+
+
+def replay_to_sec(replay: ReplayEntry) -> SECTask:
+    """Generate a :class:`SECTask` from a :class:`ReplayEntry`."""
+    category = _choose_category(replay)
+    template_context: Dict[str, Any] = {
+        "attack_type": replay.feedback_signal or "unknown",
+        "input": replay.input_event,
+    }
+    instruction = render_template(category, template_context)
+    task_id = f"SEC-{datetime.utcnow().year}-{uuid4().hex[:6]}"
+
+    version_ctx = VersionContext(
+        model=replay.version_id or "unknown",
+        decision_hash=replay.replay_id,
+    )
+
+    return SECTask(
+        task_id=task_id,
+        replay_id=replay.replay_id,
+        category=category,
+        instruction=instruction,
+        input=replay.input_event,
+        expected_output=replay.feedback_signal or "",
+        feedback=replay.replay_label,
+        version_context=version_ctx,
+        tags=["generated_from:replay"],
+        difficulty="medium",
+    )
+
+
+__all__ = ["replay_to_sec"]

--- a/src/learning/sec/sec_schema.py
+++ b/src/learning/sec/sec_schema.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Data schema for SEC micro tasks."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VersionContext(BaseModel):
+    """Model and decision version identifiers."""
+
+    model: str = Field(description="Model identifier used")
+    decision_hash: str = Field(description="Hash of the decision trace")
+
+
+class SECTask(BaseModel):
+    """Structured record capturing a single SEC training task."""
+
+    task_id: str = Field(
+        description="Globally unique task identifier",
+    )
+    replay_id: str = Field(
+        description="Replay entry this task originated from",
+    )
+    category: str = Field(description="Training task category")
+    instruction: str = Field(description="Instruction text for the model")
+    input: Dict[str, Any] | str = Field(
+        description="Input payload for the task",
+    )
+    expected_output: str = Field(description="Expected model answer")
+    feedback: Optional[str] = Field(
+        default=None,
+        description="Replay feedback",
+    )
+    version_context: VersionContext = Field(description="Version metadata")
+    tags: List[str] = Field(
+        default_factory=list,
+        description="Auxiliary labels",
+    )
+    difficulty: str = Field(
+        default="medium",
+        description="Relative task difficulty",
+    )
+
+
+__all__ = ["SECTask", "VersionContext"]

--- a/src/learning/sec/templates.py
+++ b/src/learning/sec/templates.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Prompt templates for SEC task generation."""
+
+from jinja2 import Environment, StrictUndefined
+
+
+TEMPLATES = {
+    "intrusion_categorization": (
+        "請判斷下列事件是否與 {{ attack_type }} 攻擊有關。"
+        "\n{{ input | tojson }}"
+    ),
+    "input_sanitation": (
+        "以下輸入可能包含惡意指令。" "請給出清理後的安全內容：\n{{ input }}"
+    ),
+}
+
+_env = Environment(undefined=StrictUndefined)
+
+
+def render_template(name: str, context: dict) -> str:
+    """Render the template with the provided context."""
+    if name not in TEMPLATES:
+        raise ValueError(f"Unknown template: {name}")
+    template = _env.from_string(TEMPLATES[name])
+    return template.render(**context)
+
+
+__all__ = ["render_template", "TEMPLATES"]

--- a/tests/unit/learning/sec/test_generator.py
+++ b/tests/unit/learning/sec/test_generator.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from datetime import datetime, timezone
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.replay import ReplayEntry  # noqa: E402
+from src.learning.sec import replay_to_sec  # noqa: E402
+
+
+def test_replay_to_sec():
+    replay = ReplayEntry(
+        replay_id="r1",
+        timestamp=datetime.now(timezone.utc),
+        input_event={"event": "x"},
+        feedback_signal="lateral_movement",
+        replay_label="misclassification",
+        version_id="m-7b",
+    )
+
+    sec = replay_to_sec(replay)
+    assert sec.replay_id == "r1"
+    assert "lateral_movement" in sec.instruction
+    assert sec.version_context.model == "m-7b"

--- a/tests/unit/learning/sec/test_schema.py
+++ b/tests/unit/learning/sec/test_schema.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.sec import SECTask, VersionContext  # noqa: E402
+
+
+def test_schema_instantiation():
+    version = VersionContext(model="m1", decision_hash="abc")
+    task = SECTask(
+        task_id="SEC-1",
+        replay_id="r1",
+        category="intrusion_categorization",
+        instruction="instr",
+        input={"k": "v"},
+        expected_output="ans",
+        feedback="label",
+        version_context=version,
+        tags=["t"],
+        difficulty="easy",
+    )
+    assert task.task_id == "SEC-1"
+    assert task.version_context.model == "m1"

--- a/tests/unit/learning/sec/test_templates.py
+++ b/tests/unit/learning/sec/test_templates.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.sec import render_template  # noqa: E402
+
+
+def test_render_template():
+    result = render_template(
+        "intrusion_categorization",
+        {"attack_type": "lateral movement", "input": {"k": 1}},
+    )
+    assert "lateral movement" in result


### PR DESCRIPTION
## Summary
- implement SEC Generator under `src/learning/sec`
- include prompt templates and schema definitions
- expose SEC utilities from `learning` package
- add unit tests for schema, templates, and generator

## Testing
- `flake8 src/learning/sec src/learning/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7e2e5604832fa9ce8320df3f330b