### PR TITLE
Implement Self-Refinement module

### DIFF
--- a/src/learning/refinement/__init__.py
+++ b/src/learning/refinement/__init__.py
@@ -1,0 +1,14 @@
+"""Self-refinement utilities for iterative output improvement."""
+
+from .refinement_schema import RefinementEntry
+from .critic_prompt_builder import build_prompt
+from .self_refiner import SelfRefiner, TextAgent
+from .multi_pass_runner import MultiPassRunner
+
+__all__ = [
+    "RefinementEntry",
+    "build_prompt",
+    "SelfRefiner",
+    "TextAgent",
+    "MultiPassRunner",
+]

--- a/src/learning/refinement/critic_prompt_builder.py
+++ b/src/learning/refinement/critic_prompt_builder.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Utility to build prompts for critic models."""
+
+from typing import Iterable, List, Optional
+
+
+def build_prompt(
+    draft: str,
+    *,
+    context: str = "",
+    indicators: Optional[Iterable[str]] = None,
+) -> str:
+    """Assemble a review prompt from components."""
+    parts: List[str] = []
+    if context:
+        parts.append(f"Context:\n{context}")
+    parts.append(f"Output to review:\n{draft}")
+    if indicators:
+        lines = "\n".join(f"- {i}" for i in indicators)
+        parts.append(f"Consider the following aspects:\n{lines}")
+    return "\n\n".join(parts)
+
+
+__all__ = ["build_prompt"]

--- a/src/learning/refinement/multi_pass_runner.py
+++ b/src/learning/refinement/multi_pass_runner.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Control logic for multi-pass refinement."""
+
+from typing import List, Optional
+
+from .self_refiner import SelfRefiner
+from .refinement_schema import RefinementEntry
+
+
+class MultiPassRunner:
+    """Execute refinement loops until convergence or max rounds."""
+
+    def __init__(
+        self,
+        refiner: SelfRefiner,
+        max_rounds: int = 3,
+        score_delta: float = 0.01,
+    ) -> None:
+        self.refiner = refiner
+        self.max_rounds = max_rounds
+        self.score_delta = score_delta
+
+    def run(
+        self,
+        task_id: str,
+        prompt: str,
+        *,
+        context: str = "",
+        indicators: Optional[List[str]] = None,
+    ) -> List[RefinementEntry]:
+        """Run the configured refinement process."""
+        return self.refiner.run_refinement_loop(
+            task_id,
+            prompt,
+            rounds=self.max_rounds,
+            context=context,
+            indicators=indicators,
+            score_delta=self.score_delta,
+        )
+
+
+__all__ = ["MultiPassRunner"]

--- a/src/learning/refinement/refinement_schema.py
+++ b/src/learning/refinement/refinement_schema.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Data schema for self-refinement rounds."""
+
+from pydantic import BaseModel, Field
+
+
+class RefinementEntry(BaseModel):
+    """Record of a single refinement iteration."""
+
+    task_id: str = Field(description="Associated task identifier")
+    round: int = Field(description="Refinement round number")
+    initial_output: str = Field(description="Original draft output")
+    review_comment: str = Field(description="Critic feedback for the draft")
+    revised_output: str = Field(
+        description="Output rewritten after review",
+    )
+    improvement_score: float = Field(
+        description="Similarity score between drafts",
+    )
+    final_flag: bool = Field(
+        default=False,
+        description="Flag if this is the last round",
+    )
+
+
+__all__ = ["RefinementEntry"]

--- a/src/learning/refinement/self_refiner.py
+++ b/src/learning/refinement/self_refiner.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Simple implementation of a self-refinement cycle."""
+
+from typing import Iterable, List, Optional, Protocol
+
+from src.inference.cit_controller import compute_similarity
+
+from .critic_prompt_builder import build_prompt
+from .refinement_schema import RefinementEntry
+
+
+class TextAgent(Protocol):
+    """Minimal protocol for text generation."""
+
+    def run(self, prompt: str) -> str:  # pragma: no cover - interface only
+        ...
+
+
+class SelfRefiner:
+    """Handle draft generation, review and rewriting."""
+
+    def __init__(self, agent: TextAgent) -> None:
+        self.agent = agent
+
+    def generate_initial(self, prompt: str) -> str:
+        """Generate the initial draft from the prompt."""
+        return self.agent.run(prompt)
+
+    def review_output(
+        self,
+        draft: str,
+        *,
+        context: str = "",
+        indicators: Optional[Iterable[str]] = None,
+    ) -> str:
+        """Return reviewer comments for the draft."""
+        review_prompt = build_prompt(
+            draft,
+            context=context,
+            indicators=indicators,
+        )
+        return self.agent.run(review_prompt)
+
+    def apply_revision(self, prompt: str, draft: str, review: str) -> str:
+        """Apply reviewer feedback to generate a revised draft."""
+        rewrite_prompt = (
+            f"Original prompt: {prompt}\n"
+            f"Current answer: {draft}\n"
+            f"Critique: {review}\n"
+            "\nRewrite the answer incorporating the critique."
+        )
+        return self.agent.run(rewrite_prompt)
+
+    def run_refinement_loop(
+        self,
+        task_id: str,
+        prompt: str,
+        *,
+        rounds: int = 1,
+        context: str = "",
+        indicators: Optional[List[str]] = None,
+        score_delta: float = 0.01,
+    ) -> List[RefinementEntry]:
+        """Execute a multi-pass refinement loop."""
+        results: List[RefinementEntry] = []
+        current = self.generate_initial(prompt)
+        prev_score = 0.0
+
+        for i in range(1, rounds + 1):
+            review = self.review_output(
+                current,
+                context=context,
+                indicators=indicators,
+            )
+            revised = self.apply_revision(prompt, current, review)
+            score = compute_similarity(current, revised, "jaccard")
+            results.append(
+                RefinementEntry(
+                    task_id=task_id,
+                    round=i,
+                    initial_output=current,
+                    review_comment=review,
+                    revised_output=revised,
+                    improvement_score=score,
+                    final_flag=False,
+                )
+            )
+            if abs(score - prev_score) < score_delta:
+                results[-1].final_flag = True
+                break
+            current = revised
+            prev_score = score
+
+        if results:
+            results[-1].final_flag = True
+        return results
+
+
+__all__ = ["SelfRefiner", "TextAgent"]

--- a/tests/unit/learning/refinement/test_multi_pass_runner.py
+++ b/tests/unit/learning/refinement/test_multi_pass_runner.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.refinement.self_refiner import SelfRefiner  # noqa: E402
+from src.learning.refinement.multi_pass_runner import (  # noqa: E402
+    MultiPassRunner,
+)
+
+
+class DummyAgent:
+    def __init__(self, outputs):
+        self.outputs = list(outputs)
+
+    def run(self, prompt: str) -> str:
+        return self.outputs.pop(0)
+
+
+def test_multi_round_runner():
+    agent = DummyAgent([
+        "draft",
+        "review1",
+        "rev1",
+        "review2",
+        "rev2",
+    ])
+    refiner = SelfRefiner(agent)
+    runner = MultiPassRunner(refiner, max_rounds=2)
+    records = runner.run("t1", "prompt")
+    assert len(records) >= 1
+    assert records[-1].final_flag is True

--- a/tests/unit/learning/refinement/test_output_struct.py
+++ b/tests/unit/learning/refinement/test_output_struct.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.refinement.refinement_schema import (  # noqa: E402
+    RefinementEntry,
+)
+
+
+def test_refinement_entry_serialization():
+    entry = RefinementEntry(
+        task_id="t",
+        round=1,
+        initial_output="d1",
+        review_comment="good",
+        revised_output="d2",
+        improvement_score=0.5,
+        final_flag=True,
+    )
+    data = entry.model_dump()
+    assert data["task_id"] == "t"
+    assert data["final_flag"] is True

--- a/tests/unit/learning/refinement/test_prompt_builder.py
+++ b/tests/unit/learning/refinement/test_prompt_builder.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.refinement.critic_prompt_builder import (  # noqa: E402
+    build_prompt,
+)
+
+
+def test_build_prompt_includes_parts():
+    text = build_prompt("draft", context="ctx", indicators=["a", "b"])
+    assert "ctx" in text
+    assert "draft" in text
+    assert "a" in text and "b" in text

--- a/tests/unit/learning/refinement/test_self_refiner.py
+++ b/tests/unit/learning/refinement/test_self_refiner.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+CURRENT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT, "..", "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from src.learning.refinement.self_refiner import SelfRefiner  # noqa: E402
+
+
+class DummyAgent:
+    def __init__(self, outputs):
+        self.outputs = list(outputs)
+
+    def run(self, prompt: str) -> str:
+        return self.outputs.pop(0)
+
+
+def test_single_round_refinement():
+    agent = DummyAgent(["draft", "review", "revised"])
+    refiner = SelfRefiner(agent)
+    records = refiner.run_refinement_loop("t1", "prompt", rounds=1)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.review_comment == "review"
+    assert rec.revised_output == "revised"
+    assert rec.final_flag is True


### PR DESCRIPTION
## Summary
- add self-refinement utilities under `src/learning/refinement`
- implement `SelfRefiner`, prompt builder, iteration runner and schema
- include unit tests for building prompts, schema serialization and refinement loop

## Testing
- `flake8 src/learning/refinement tests/unit/learning/refinement`
- `pytest tests/unit/learning/refinement -q`


------
https://chatgpt.com/codex/tasks/task_e_688b92629930832fab99b8aad1c38c6e